### PR TITLE
[#24]fix: ログアウトルートを認証不要に変更

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -16,6 +16,11 @@ Route::prefix('auth')->group(function () {
     Route::post('/refresh', [AuthController::class, 'refresh']);
 });
 
+// ログアウト（認証不要だがCookieは読む）
+Route::prefix('auth')->middleware([JwtFromCookie::class])->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+});
+
 // レッスン（認証不要：一覧・詳細）
 Route::prefix('lessons')->group(function () {
     Route::get('/', [LessonController::class, 'index']);
@@ -31,7 +36,6 @@ Route::prefix('schedules')->group(function () {
 // 認証必要（JWT + Cookie）
 Route::middleware([JwtFromCookie::class, 'auth:api'])->group(function () {
     Route::prefix('auth')->group(function () {
-        Route::post('/logout', [AuthController::class, 'logout']);
         Route::get('/me', [AuthController::class, 'me']);
     });
 


### PR DESCRIPTION
## Ticket / Issue Number
#24
#25 

## What's changed

ログアウト時に401エラーが発生する問題を修正しました。

* `/auth/logout`を`auth:api`ミドルウェアから除外
* 認証状態に関わらずログアウト可能に

### 変更前
```php
Route::middleware([JwtFromCookie::class, 'auth:api'])->group(function () {
    Route::post('/logout', ...);  // ← 認証必須
});
変更後

Route::middleware([JwtFromCookie::class])->group(function () {
    Route::post('/logout', ...);  // ← 認証不要（Cookieのみ読む）
});


## Todo List
なし

## Check List

- [ ] ログアウトが正常に動作する
- [ ]  トークン期限切れ時もログアウト可能

## Remark
auth:apiミドルウェアはJWT検証に失敗すると401を返し、リクエストを拒否する
ログアウトは「認証状態に関わらず実行すべき」処理
Cookie読み取り（JwtFromCookie）は必要だが、認証検証（auth:api）は不要