### PR TITLE
[#34]feat: チケット購入ページと予約確認フローを追加

### DIFF
--- a/frontend/src/app/lessons/[id]/page.tsx
+++ b/frontend/src/app/lessons/[id]/page.tsx
@@ -13,7 +13,6 @@ export default function LessonDetailPage() {
   const { user } = useAuth();
   const [lesson, setLesson] = useState<Lesson | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [reservingId, setReservingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (params.id) {
@@ -34,23 +33,12 @@ export default function LessonDetailPage() {
     }
   };
 
-  const handleReserve = async (scheduleId: number) => {
+  const handleReserve = (scheduleId: number) => {
     if (!user) {
       router.push('/login');
       return;
     }
-
-    setReservingId(scheduleId);
-    try {
-      await api.post('/reservations', { schedule_id: scheduleId });
-      alert('予約が完了しました');
-      fetchLesson(); // 予約数を更新
-    } catch (error: unknown) {
-      const err = error as { response?: { data?: { message?: string } } };
-      alert(err.response?.data?.message || '予約に失敗しました');
-    } finally {
-      setReservingId(null);
-    }
+    router.push(`/reservations/confirm?schedule_id=${scheduleId}`);
   };
 
   const formatDate = (dateString: string) => {
@@ -182,18 +170,14 @@ export default function LessonDetailPage() {
                           </span>
                           <button
                             onClick={() => handleReserve(schedule.id)}
-                            disabled={schedule.is_full || reservingId === schedule.id}
+                            disabled={schedule.is_full}
                             className={`px-4 py-2 rounded-full text-sm font-medium transition ${
                               schedule.is_full
                                 ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
                                 : 'bg-orange-500 text-white hover:bg-orange-600'
                             }`}
                           >
-                            {reservingId === schedule.id
-                              ? '予約中...'
-                              : schedule.is_full
-                              ? '満席'
-                              : '予約する'}
+                            {schedule.is_full ? '満席' : '予約する'}
                           </button>
                         </div>
                       </div>

--- a/frontend/src/app/reservations/complete/page.tsx
+++ b/frontend/src/app/reservations/complete/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function ReservationCompletePage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <section className="bg-green-600 text-white py-8">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* Steps */}
+          <div className="flex items-center justify-center mb-6">
+            <div className="flex items-center opacity-50">
+              <div className="w-8 h-8 border-2 border-white rounded-full flex items-center justify-center font-bold">
+                1
+              </div>
+              <span className="ml-2 text-sm">選択</span>
+            </div>
+            <div className="w-12 h-0.5 bg-white mx-2"></div>
+            <div className="flex items-center opacity-50">
+              <div className="w-8 h-8 border-2 border-white rounded-full flex items-center justify-center font-bold">
+                2
+              </div>
+              <span className="ml-2 text-sm">確認</span>
+            </div>
+            <div className="w-12 h-0.5 bg-white mx-2"></div>
+            <div className="flex items-center">
+              <div className="w-8 h-8 bg-white text-green-600 rounded-full flex items-center justify-center font-bold">
+                3
+              </div>
+              <span className="ml-2 text-sm font-bold">完了</span>
+            </div>
+          </div>
+          <h1 className="text-2xl md:text-3xl font-bold text-center">予約完了</h1>
+        </div>
+      </section>
+
+      {/* Content */}
+      <section className="py-12">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
+            <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
+              <svg
+                className="w-10 h-10 text-green-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+
+            <h2 className="text-2xl font-bold text-gray-800 mb-4">
+              予約が完了しました
+            </h2>
+            <p className="text-gray-600 mb-8">
+              レッスンの予約が完了しました。<br />
+              マイページから予約内容をご確認いただけます。
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link
+                href="/mypage"
+                className="px-8 py-4 bg-orange-500 text-white rounded-full font-bold hover:bg-orange-600 transition"
+              >
+                マイページで確認
+              </Link>
+              <Link
+                href="/lessons"
+                className="px-8 py-4 border-2 border-gray-300 text-gray-700 rounded-full font-bold hover:bg-gray-50 transition"
+              >
+                他のレッスンを探す
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/reservations/confirm/page.tsx
+++ b/frontend/src/app/reservations/confirm/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { Schedule } from '@/types/lesson';
+import { Ticket } from '@/types/reservation';
+
+type ScheduleWithLesson = Schedule & {
+  lesson?: {
+    id: number;
+    title: string;
+    category: string;
+    category_label: string;
+    difficulty: string;
+    difficulty_label: string;
+  };
+};
+
+export default function ReservationConfirmPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const scheduleId = searchParams.get('schedule_id');
+  const { user, isLoading: authLoading } = useAuth();
+  const [schedule, setSchedule] = useState<ScheduleWithLesson | null>(null);
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/login');
+    }
+  }, [authLoading, user, router]);
+
+  useEffect(() => {
+    if (user && scheduleId) {
+      fetchData();
+    }
+  }, [user, scheduleId]);
+
+  const fetchData = async () => {
+    setIsLoading(true);
+    try {
+      const [scheduleRes, ticketsRes] = await Promise.all([
+        api.get(`/schedules/${scheduleId}`),
+        api.get('/tickets'),
+      ]);
+      setSchedule(scheduleRes.data.data);
+      setTickets(ticketsRes.data.data);
+    } catch (error) {
+      console.error('データの取得に失敗しました', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!scheduleId) return;
+
+    setIsSubmitting(true);
+    try {
+      await api.post('/reservations', { schedule_id: Number(scheduleId) });
+      router.push('/reservations/complete');
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { message?: string } } };
+      alert(err.response?.data?.message || '予約に失敗しました');
+      setIsSubmitting(false);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      weekday: 'short',
+    });
+  };
+
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleTimeString('ja-JP', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const totalRemainingTickets = tickets
+    .filter((t) => t.is_valid)
+    .reduce((sum, t) => sum + t.remaining_count, 0);
+
+  if (authLoading || isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-orange-500 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  if (!schedule) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-gray-600">スケジュールが見つかりませんでした</p>
+          <Link href="/lessons" className="mt-4 inline-block text-orange-500 hover:underline">
+            レッスン一覧に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <section className="bg-orange-500 text-white py-8">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* Steps */}
+          <div className="flex items-center justify-center mb-6">
+            <div className="flex items-center">
+              <div className="w-8 h-8 bg-white text-orange-500 rounded-full flex items-center justify-center font-bold">
+                1
+              </div>
+              <span className="ml-2 text-sm">選択</span>
+            </div>
+            <div className="w-12 h-0.5 bg-white mx-2"></div>
+            <div className="flex items-center">
+              <div className="w-8 h-8 bg-white text-orange-500 rounded-full flex items-center justify-center font-bold">
+                2
+              </div>
+              <span className="ml-2 text-sm font-bold">確認</span>
+            </div>
+            <div className="w-12 h-0.5 bg-white/50 mx-2"></div>
+            <div className="flex items-center opacity-50">
+              <div className="w-8 h-8 border-2 border-white rounded-full flex items-center justify-center font-bold">
+                3
+              </div>
+              <span className="ml-2 text-sm">完了</span>
+            </div>
+          </div>
+          <h1 className="text-2xl md:text-3xl font-bold text-center">予約内容の確認</h1>
+        </div>
+      </section>
+
+      {/* Content */}
+      <section className="py-8">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* Reservation Details */}
+          <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
+            <h2 className="text-lg font-bold text-gray-800 mb-4">予約内容</h2>
+
+            {schedule.lesson && (
+              <div className="border-b pb-4 mb-4">
+                <div className="text-sm text-gray-500 mb-1">レッスン</div>
+                <div className="text-xl font-bold text-gray-800">{schedule.lesson.title}</div>
+                <div className="flex gap-2 mt-2">
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-1 rounded">
+                    {schedule.lesson.category_label}
+                  </span>
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-1 rounded">
+                    {schedule.lesson.difficulty_label}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <div className="text-sm text-gray-500 mb-1">日時</div>
+                <div className="font-medium text-gray-800">
+                  {formatDate(schedule.start_at)}
+                </div>
+                <div className="text-gray-600">
+                  {formatTime(schedule.start_at)} - {formatTime(schedule.end_at)}
+                </div>
+              </div>
+              {schedule.instructor && (
+                <div>
+                  <div className="text-sm text-gray-500 mb-1">講師</div>
+                  <div className="font-medium text-gray-800">{schedule.instructor.name}</div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Ticket Info */}
+          <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
+            <h2 className="text-lg font-bold text-gray-800 mb-4">チケット情報</h2>
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm text-gray-500 mb-1">使用チケット</div>
+                <div className="font-medium text-gray-800">1回分</div>
+              </div>
+              <div className="text-right">
+                <div className="text-sm text-gray-500 mb-1">残りチケット</div>
+                <div className="font-medium text-gray-800">
+                  {totalRemainingTickets}回 → {totalRemainingTickets - 1}回
+                </div>
+              </div>
+            </div>
+
+            {totalRemainingTickets === 0 && (
+              <div className="mt-4 p-4 bg-red-50 rounded-xl">
+                <p className="text-red-600 text-sm">
+                  チケットがありません。先にチケットを購入してください。
+                </p>
+                <Link
+                  href="/tickets/purchase"
+                  className="mt-2 inline-block text-red-600 hover:underline text-sm font-medium"
+                >
+                  チケットを購入する →
+                </Link>
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-4">
+            <button
+              onClick={() => router.back()}
+              className="flex-1 py-4 rounded-full border-2 border-gray-300 text-gray-700 font-bold hover:bg-gray-50 transition"
+            >
+              戻る
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={isSubmitting || totalRemainingTickets === 0}
+              className={`flex-1 py-4 rounded-full font-bold transition ${
+                isSubmitting || totalRemainingTickets === 0
+                  ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  : 'bg-orange-500 text-white hover:bg-orange-600'
+              }`}
+            >
+              {isSubmitting ? '予約中...' : '予約を確定する'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/tickets/purchase/page.tsx
+++ b/frontend/src/app/tickets/purchase/page.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+type Plan = {
+  id: string;
+  name: string;
+  count: number;
+  price: number;
+  pricePerLesson: number;
+  validDays: number;
+  popular?: boolean;
+};
+
+const plans: Plan[] = [
+  {
+    id: 'single',
+    name: '1回券',
+    count: 1,
+    price: 3000,
+    pricePerLesson: 3000,
+    validDays: 30,
+  },
+  {
+    id: 'five',
+    name: '5回券',
+    count: 5,
+    price: 13500,
+    pricePerLesson: 2700,
+    validDays: 90,
+    popular: true,
+  },
+  {
+    id: 'ten',
+    name: '10回券',
+    count: 10,
+    price: 25000,
+    pricePerLesson: 2500,
+    validDays: 180,
+  },
+];
+
+export default function TicketPurchasePage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/login');
+    }
+  }, [authLoading, user, router]);
+
+  const handlePurchase = async () => {
+    if (!selectedPlan) {
+      alert('プランを選択してください');
+      return;
+    }
+
+    setIsPurchasing(true);
+    try {
+      await api.post('/tickets', { plan: selectedPlan });
+      alert('チケットを購入しました');
+      router.push('/mypage');
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { message?: string } } };
+      alert(err.response?.data?.message || '購入に失敗しました');
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (authLoading || (!user && !authLoading)) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-orange-500 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <section className="bg-green-600 text-white py-12">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Link href="/mypage" className="inline-flex items-center text-white/80 hover:text-white mb-4">
+            <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            マイページに戻る
+          </Link>
+          <h1 className="text-3xl md:text-4xl font-bold">チケット購入</h1>
+          <p className="mt-2 text-green-100">お得なチケットでレッスンを受講しましょう</p>
+        </div>
+      </section>
+
+      {/* Plans */}
+      <section className="py-12">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {plans.map((plan) => (
+              <div
+                key={plan.id}
+                onClick={() => setSelectedPlan(plan.id)}
+                className={`relative bg-white rounded-2xl shadow-lg p-6 cursor-pointer transition-all ${
+                  selectedPlan === plan.id
+                    ? 'ring-4 ring-green-500 scale-105'
+                    : 'hover:shadow-xl'
+                }`}
+              >
+                {plan.popular && (
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+                    <span className="bg-orange-500 text-white text-xs font-bold px-3 py-1 rounded-full">
+                      人気
+                    </span>
+                  </div>
+                )}
+
+                <div className="text-center">
+                  <h3 className="text-2xl font-bold text-gray-800 mb-2">{plan.name}</h3>
+                  <div className="text-4xl font-bold text-green-600 mb-1">
+                    ¥{plan.price.toLocaleString()}
+                  </div>
+                  <div className="text-sm text-gray-500 mb-4">
+                    1回あたり ¥{plan.pricePerLesson.toLocaleString()}
+                  </div>
+
+                  <div className="border-t pt-4 space-y-2 text-sm text-gray-600">
+                    <div className="flex justify-between">
+                      <span>レッスン回数</span>
+                      <span className="font-medium">{plan.count}回</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>有効期限</span>
+                      <span className="font-medium">{plan.validDays}日間</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-4">
+                    <div
+                      className={`w-6 h-6 mx-auto rounded-full border-2 flex items-center justify-center ${
+                        selectedPlan === plan.id
+                          ? 'border-green-500 bg-green-500'
+                          : 'border-gray-300'
+                      }`}
+                    >
+                      {selectedPlan === plan.id && (
+                        <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Purchase Button */}
+          <div className="mt-12 text-center">
+            <button
+              onClick={handlePurchase}
+              disabled={!selectedPlan || isPurchasing}
+              className={`px-12 py-4 rounded-full text-lg font-bold transition ${
+                selectedPlan && !isPurchasing
+                  ? 'bg-green-600 text-white hover:bg-green-700'
+                  : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+              }`}
+            >
+              {isPurchasing ? '処理中...' : '購入する'}
+            </button>
+            <p className="mt-4 text-sm text-gray-500">
+              ※ デモ版のため、実際の決済は行われません
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Ticket / Issue Number

#34

## What's changed

チケット購入ページと予約確認フローを追加しました。

* チケット購入ページ（`/tickets/purchase`）を追加
  - 1回券・5回券・10回券の3プランを表示
  - 各プランの価格と説明を表示
* 予約フローを3ステップ（選択→確認→完了）に改善
  - 予約確認ページ（`/reservations/confirm`）を追加
  - 予約完了ページ（`/reservations/complete`）を追加
* レッスン詳細ページの予約ボタンを確認ページへ遷移するように変更
* チケット残数を確認ページで表示し、不足時は購入ページへの導線を追加

## Todo List

- [ ] チケット購入APIとの連携
- [ ] 決済機能の実装

## Check List

- [x] チケット購入ページで3つのプランが表示される
- [x] レッスン詳細ページの「予約する」ボタンで確認ページに遷移する
- [x] 確認ページでスケジュール詳細とチケット残数が表示される
- [x] チケットがない場合、購入ページへの導線が表示される
- [x] 予約確定後、完了ページに遷移する

## Remark