### PR TITLE
[#48]feat: UI/UXデザインをナチュラルテーマに統一

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function AboutPage() {
+  const { user } = useAuth();
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-16 md:py-24">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Link href="/" className="inline-flex items-center text-stone-600 hover:text-emerald-700 mb-6 transition">
+            <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            トップに戻る
+          </Link>
+          <p className="text-emerald-700 font-medium mb-2">About Us</p>
+          <h1 className="text-3xl md:text-5xl font-bold text-stone-800 mb-6">
+            おうち<span className="text-emerald-700">シェフ</span>とは
+          </h1>
+          <p className="text-xl text-stone-600 max-w-3xl leading-relaxed">
+            おうちシェフは、プロの料理人から直接学べるオンライン料理教室です。
+            自宅のキッチンで、本格的な料理のテクニックを身につけましょう。
+          </p>
+        </div>
+      </section>
+
+      {/* Mission */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="bg-white rounded-2xl border border-stone-100 p-8 md:p-12">
+            <h2 className="text-2xl md:text-3xl font-bold text-stone-800 mb-6 text-center">
+              私たちのミッション
+            </h2>
+            <p className="text-lg text-stone-600 text-center max-w-3xl mx-auto leading-relaxed">
+              「毎日の食卓を、もっと豊かに。」<br />
+              料理を通じて、家族との時間を特別なものに変えていく。
+              それがおうちシェフの願いです。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="py-16 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <p className="text-emerald-700 font-medium mb-2">Features</p>
+            <h2 className="text-2xl md:text-3xl font-bold text-stone-800">
+              おうちシェフの特徴
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            <div className="bg-gradient-to-br from-amber-50 to-stone-50 rounded-2xl p-8">
+              <div className="w-14 h-14 bg-amber-100 rounded-xl flex items-center justify-center mb-6">
+                <svg className="w-7 h-7 text-amber-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                </svg>
+              </div>
+              <h3 className="text-xl font-bold text-stone-800 mb-3">
+                プロの技を自宅で
+              </h3>
+              <p className="text-stone-600 leading-relaxed">
+                現役のプロ料理人が直接指導。レストランで提供される本格的な料理のコツを、ご自宅のキッチンで学べます。
+              </p>
+            </div>
+
+            <div className="bg-gradient-to-br from-emerald-50 to-stone-50 rounded-2xl p-8">
+              <div className="w-14 h-14 bg-emerald-100 rounded-xl flex items-center justify-center mb-6">
+                <svg className="w-7 h-7 text-emerald-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                </svg>
+              </div>
+              <h3 className="text-xl font-bold text-stone-800 mb-3">
+                少人数制レッスン
+              </h3>
+              <p className="text-stone-600 leading-relaxed">
+                各クラスは少人数制で開催。講師との距離が近く、質問もしやすい環境で、確実にスキルアップできます。
+              </p>
+            </div>
+
+            <div className="bg-gradient-to-br from-sky-50 to-stone-50 rounded-2xl p-8">
+              <div className="w-14 h-14 bg-sky-100 rounded-xl flex items-center justify-center mb-6">
+                <svg className="w-7 h-7 text-sky-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <h3 className="text-xl font-bold text-stone-800 mb-3">
+                オンラインで参加
+              </h3>
+              <p className="text-stone-600 leading-relaxed">
+                インターネット環境があればどこからでも参加可能。通学の手間なく、お好きな時間にレッスンを受けられます。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <p className="text-emerald-700 font-medium mb-2">How it works</p>
+            <h2 className="text-2xl md:text-3xl font-bold text-stone-800">
+              ご利用の流れ
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+            {[
+              { step: '01', title: '会員登録', desc: '無料でアカウントを作成します' },
+              { step: '02', title: 'チケット購入', desc: 'お好きなプランのチケットを購入' },
+              { step: '03', title: 'レッスン予約', desc: '参加したいレッスンを選んで予約' },
+              { step: '04', title: 'オンラインで参加', desc: '当日はZoomなどで参加' },
+            ].map((item) => (
+              <div key={item.step} className="bg-white rounded-2xl border border-stone-100 p-6 text-center">
+                <div className="w-12 h-12 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <span className="text-emerald-700 font-bold">{item.step}</span>
+                </div>
+                <h3 className="font-bold text-stone-800 mb-2">{item.title}</h3>
+                <p className="text-sm text-stone-600">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Categories */}
+      <section className="py-16 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <p className="text-emerald-700 font-medium mb-2">Categories</p>
+            <h2 className="text-2xl md:text-3xl font-bold text-stone-800">
+              学べるジャンル
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {[
+              { name: '和食', color: 'amber', desc: '伝統的な日本料理' },
+              { name: '洋食', color: 'orange', desc: 'フレンチ・イタリアンなど' },
+              { name: '中華', color: 'red', desc: '本格中華料理' },
+              { name: 'スイーツ', color: 'pink', desc: 'お菓子・デザート' },
+            ].map((category) => (
+              <div
+                key={category.name}
+                className={`bg-${category.color}-50 rounded-2xl p-6 text-center border border-${category.color}-100`}
+              >
+                <h3 className={`text-lg font-bold text-${category.color}-800 mb-1`}>
+                  {category.name}
+                </h3>
+                <p className={`text-sm text-${category.color}-600`}>
+                  {category.desc}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="bg-gradient-to-br from-emerald-700 to-emerald-800 rounded-2xl p-8 md:p-12 text-center">
+            <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+              あなたも今日から始めませんか？
+            </h2>
+            <p className="text-emerald-100 mb-8 max-w-2xl mx-auto">
+              おうちシェフで、プロの料理人から直接学ぶ楽しさを体験してください。
+              初心者の方も大歓迎です。
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              {user ? (
+                <>
+                  <Link
+                    href="/lessons"
+                    className="inline-block bg-white text-emerald-700 px-8 py-4 rounded-xl font-bold hover:bg-emerald-50 transition"
+                  >
+                    レッスンを探す
+                  </Link>
+                  <Link
+                    href="/mypage"
+                    className="inline-block bg-emerald-600 text-white px-8 py-4 rounded-xl font-bold hover:bg-emerald-500 transition border border-emerald-500"
+                  >
+                    マイページへ
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/register"
+                    className="inline-block bg-white text-emerald-700 px-8 py-4 rounded-xl font-bold hover:bg-emerald-50 transition"
+                  >
+                    無料会員登録
+                  </Link>
+                  <Link
+                    href="/lessons"
+                    className="inline-block bg-emerald-600 text-white px-8 py-4 rounded-xl font-bold hover:bg-emerald-500 transition border border-emerald-500"
+                  >
+                    レッスンを見る
+                  </Link>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/lessons/[id]/page.tsx
+++ b/frontend/src/app/lessons/[id]/page.tsx
@@ -22,7 +22,6 @@ export default function LessonDetailPage() {
     }
   }, [params.id]);
 
-  // 閲覧履歴をストアに保存
   useEffect(() => {
     if (lesson) {
       addViewedLesson({
@@ -75,31 +74,40 @@ export default function LessonDetailPage() {
     });
   };
 
-  const getCategoryColor = (cat: string) => {
+  const getCategoryStyle = (cat: string) => {
     switch (cat) {
-      case 'japanese': return 'bg-red-500';
-      case 'western': return 'bg-yellow-500';
-      case 'chinese': return 'bg-orange-500';
-      case 'sweets': return 'bg-pink-500';
-      default: return 'bg-gray-500';
+      case 'japanese':
+        return { bg: 'bg-amber-100', text: 'text-amber-800', gradient: 'from-amber-50 to-stone-50' };
+      case 'western':
+        return { bg: 'bg-orange-100', text: 'text-orange-800', gradient: 'from-orange-50 to-stone-50' };
+      case 'chinese':
+        return { bg: 'bg-red-100', text: 'text-red-800', gradient: 'from-red-50 to-stone-50' };
+      case 'sweets':
+        return { bg: 'bg-pink-100', text: 'text-pink-800', gradient: 'from-pink-50 to-stone-50' };
+      default:
+        return { bg: 'bg-stone-100', text: 'text-stone-800', gradient: 'from-stone-100 to-stone-50' };
     }
   };
 
-  const getDifficultyColor = (diff: string) => {
+  const getDifficultyStyle = (diff: string) => {
     switch (diff) {
-      case 'beginner': return 'bg-green-500';
-      case 'intermediate': return 'bg-blue-500';
-      case 'advanced': return 'bg-purple-500';
-      default: return 'bg-gray-500';
+      case 'beginner':
+        return { bg: 'bg-emerald-100', text: 'text-emerald-800' };
+      case 'intermediate':
+        return { bg: 'bg-sky-100', text: 'text-sky-800' };
+      case 'advanced':
+        return { bg: 'bg-purple-100', text: 'text-purple-800' };
+      default:
+        return { bg: 'bg-stone-100', text: 'text-stone-800' };
     }
   };
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-stone-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-orange-500 border-t-transparent"></div>
-          <p className="mt-4 text-gray-600">読み込み中...</p>
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
+          <p className="mt-4 text-stone-600">読み込み中...</p>
         </div>
       </div>
     );
@@ -107,10 +115,10 @@ export default function LessonDetailPage() {
 
   if (!lesson) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-stone-50 flex items-center justify-center">
         <div className="text-center">
-          <p className="text-gray-600">レッスンが見つかりませんでした</p>
-          <Link href="/lessons" className="mt-4 inline-block text-orange-500 hover:underline">
+          <p className="text-stone-600">レッスンが見つかりませんでした</p>
+          <Link href="/lessons" className="mt-4 inline-block text-emerald-700 hover:underline">
             レッスン一覧に戻る
           </Link>
         </div>
@@ -118,26 +126,29 @@ export default function LessonDetailPage() {
     );
   }
 
+  const catStyle = getCategoryStyle(lesson.category);
+  const diffStyle = getDifficultyStyle(lesson.difficulty);
+
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-stone-50">
       {/* Header */}
-      <section className={`${getCategoryColor(lesson.category)} text-white py-12`}>
+      <section className={`bg-gradient-to-br ${catStyle.gradient} py-12`}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link href="/lessons" className="inline-flex items-center text-white/80 hover:text-white mb-4">
+          <Link href="/lessons" className="inline-flex items-center text-stone-600 hover:text-emerald-700 mb-4 transition">
             <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             レッスン一覧に戻る
           </Link>
           <div className="flex gap-2 mb-4">
-            <span className="bg-white/20 text-white text-sm px-3 py-1 rounded-full">
+            <span className={`${catStyle.bg} ${catStyle.text} text-sm px-3 py-1 rounded-full font-medium`}>
               {lesson.category_label}
             </span>
-            <span className={`${getDifficultyColor(lesson.difficulty)} text-white text-sm px-3 py-1 rounded-full`}>
+            <span className={`${diffStyle.bg} ${diffStyle.text} text-sm px-3 py-1 rounded-full font-medium`}>
               {lesson.difficulty_label}
             </span>
           </div>
-          <h1 className="text-3xl md:text-4xl font-bold">{lesson.title}</h1>
+          <h1 className="text-3xl md:text-4xl font-bold text-stone-800">{lesson.title}</h1>
         </div>
       </section>
 
@@ -147,19 +158,19 @@ export default function LessonDetailPage() {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Main Content */}
             <div className="lg:col-span-2">
-              <div className="bg-white rounded-2xl shadow-lg p-8">
-                <h2 className="text-xl font-bold text-gray-800 mb-4">レッスン内容</h2>
-                <p className="text-gray-600 whitespace-pre-wrap">{lesson.description}</p>
+              <div className="bg-white rounded-2xl border border-stone-100 p-8">
+                <h2 className="text-xl font-bold text-stone-800 mb-4">レッスン内容</h2>
+                <p className="text-stone-600 whitespace-pre-wrap leading-relaxed">{lesson.description}</p>
               </div>
             </div>
 
             {/* Sidebar - Schedules */}
             <div className="lg:col-span-1">
-              <div className="bg-white rounded-2xl shadow-lg p-6 sticky top-24">
-                <h2 className="text-xl font-bold text-gray-800 mb-4">開催スケジュール</h2>
+              <div className="bg-white rounded-2xl border border-stone-100 p-6 sticky top-24">
+                <h2 className="text-xl font-bold text-stone-800 mb-4">開催スケジュール</h2>
 
                 {!lesson.schedules || lesson.schedules.length === 0 ? (
-                  <p className="text-gray-500 text-center py-8">
+                  <p className="text-stone-500 text-center py-8">
                     現在予定されているスケジュールはありません
                   </p>
                 ) : (
@@ -167,30 +178,30 @@ export default function LessonDetailPage() {
                     {lesson.schedules.map((schedule: Schedule) => (
                       <div
                         key={schedule.id}
-                        className="border border-gray-200 rounded-xl p-4"
+                        className="border border-stone-200 rounded-xl p-4"
                       >
-                        <div className="text-sm text-gray-500 mb-1">
+                        <div className="text-sm text-stone-500 mb-1">
                           {formatDate(schedule.start_at)}
                         </div>
-                        <div className="text-lg font-bold text-gray-800 mb-2">
+                        <div className="text-lg font-bold text-stone-800 mb-2">
                           {formatTime(schedule.start_at)} - {formatTime(schedule.end_at)}
                         </div>
                         {schedule.instructor && (
-                          <div className="text-sm text-gray-600 mb-2">
+                          <div className="text-sm text-stone-600 mb-2">
                             講師: {schedule.instructor.name}
                           </div>
                         )}
                         <div className="flex items-center justify-between">
-                          <span className={`text-sm ${schedule.is_full ? 'text-red-500' : 'text-green-600'}`}>
+                          <span className={`text-sm ${schedule.is_full ? 'text-red-600' : 'text-emerald-700'}`}>
                             残り {schedule.available_count} / {schedule.capacity} 席
                           </span>
                           <button
                             onClick={() => handleReserve(schedule.id)}
                             disabled={schedule.is_full}
-                            className={`px-4 py-2 rounded-full text-sm font-medium transition ${
+                            className={`px-4 py-2 rounded-xl text-sm font-medium transition ${
                               schedule.is_full
-                                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                                : 'bg-orange-500 text-white hover:bg-orange-600'
+                                ? 'bg-stone-200 text-stone-500 cursor-not-allowed'
+                                : 'bg-emerald-700 text-white hover:bg-emerald-800'
                             }`}
                           >
                             {schedule.is_full ? '満席' : '予約する'}
@@ -202,13 +213,13 @@ export default function LessonDetailPage() {
                 )}
 
                 {!user && (
-                  <div className="mt-4 p-4 bg-orange-50 rounded-xl text-center">
-                    <p className="text-sm text-gray-600 mb-2">
+                  <div className="mt-4 p-4 bg-amber-50 rounded-xl text-center border border-amber-100">
+                    <p className="text-sm text-stone-600 mb-2">
                       予約するにはログインが必要です
                     </p>
                     <Link
                       href="/login"
-                      className="inline-block bg-orange-500 text-white px-6 py-2 rounded-full text-sm font-medium hover:bg-orange-600 transition"
+                      className="inline-block bg-emerald-700 text-white px-6 py-2 rounded-xl text-sm font-medium hover:bg-emerald-800 transition"
                     >
                       ログイン
                     </Link>

--- a/frontend/src/app/lessons/page.tsx
+++ b/frontend/src/app/lessons/page.tsx
@@ -48,47 +48,67 @@ export default function LessonsPage() {
     }
   };
 
-  const getCategoryColor = (cat: string) => {
+  const getCategoryStyle = (cat: string) => {
     switch (cat) {
-      case 'japanese': return 'bg-red-500';
-      case 'western': return 'bg-yellow-500';
-      case 'chinese': return 'bg-orange-500';
-      case 'sweets': return 'bg-pink-500';
-      default: return 'bg-gray-500';
+      case 'japanese':
+        return { bg: 'bg-amber-100', text: 'text-amber-800', gradient: 'from-amber-100 to-amber-50' };
+      case 'western':
+        return { bg: 'bg-orange-100', text: 'text-orange-800', gradient: 'from-orange-100 to-orange-50' };
+      case 'chinese':
+        return { bg: 'bg-red-100', text: 'text-red-800', gradient: 'from-red-100 to-red-50' };
+      case 'sweets':
+        return { bg: 'bg-pink-100', text: 'text-pink-800', gradient: 'from-pink-100 to-pink-50' };
+      default:
+        return { bg: 'bg-stone-100', text: 'text-stone-800', gradient: 'from-stone-100 to-stone-50' };
     }
   };
 
-  const getDifficultyColor = (diff: string) => {
+  const getDifficultyStyle = (diff: string) => {
     switch (diff) {
-      case 'beginner': return 'bg-green-500';
-      case 'intermediate': return 'bg-blue-500';
-      case 'advanced': return 'bg-purple-500';
-      default: return 'bg-gray-500';
+      case 'beginner':
+        return { bg: 'bg-emerald-100', text: 'text-emerald-800' };
+      case 'intermediate':
+        return { bg: 'bg-sky-100', text: 'text-sky-800' };
+      case 'advanced':
+        return { bg: 'bg-purple-100', text: 'text-purple-800' };
+      default:
+        return { bg: 'bg-stone-100', text: 'text-stone-800' };
+    }
+  };
+
+  const getCategoryEmoji = (cat: string) => {
+    switch (cat) {
+      case 'japanese': return '🍱';
+      case 'western': return '🍝';
+      case 'chinese': return '🥟';
+      case 'sweets': return '🍰';
+      default: return '🍳';
     }
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-stone-50">
       {/* Header */}
-      <section className="bg-orange-500 text-white py-12">
+      <section className="bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-3xl md:text-4xl font-bold">レッスン一覧</h1>
-          <p className="mt-2 text-orange-100">お好みのレッスンを見つけましょう</p>
+          <p className="text-emerald-700 font-medium mb-2">Lesson</p>
+          <h1 className="text-3xl md:text-4xl font-bold text-stone-800">レッスン一覧</h1>
+          <p className="mt-2 text-stone-600">気になるレッスンを見つけて予約しましょう</p>
         </div>
       </section>
 
       {/* Filters */}
-      <section className="bg-white shadow-sm">
+      <section className="bg-white border-b border-stone-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex flex-wrap gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-stone-700 mb-1">
                 カテゴリ
               </label>
               <select
                 value={category}
                 onChange={(e) => setCategory(e.target.value)}
-                className="block w-40 rounded-lg border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500"
+                className="block w-40 rounded-xl border-stone-200 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"
               >
                 {categories.map((cat) => (
                   <option key={cat.value} value={cat.value}>
@@ -98,13 +118,13 @@ export default function LessonsPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-stone-700 mb-1">
                 難易度
               </label>
               <select
                 value={difficulty}
                 onChange={(e) => setDifficulty(e.target.value)}
-                className="block w-40 rounded-lg border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500"
+                className="block w-40 rounded-xl border-stone-200 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"
               >
                 {difficulties.map((diff) => (
                   <option key={diff.value} value={diff.value}>
@@ -122,48 +142,48 @@ export default function LessonsPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {isLoading ? (
             <div className="text-center py-12">
-              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-orange-500 border-t-transparent"></div>
-              <p className="mt-4 text-gray-600">読み込み中...</p>
+              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
+              <p className="mt-4 text-stone-600">読み込み中...</p>
             </div>
           ) : lessons.length === 0 ? (
             <div className="text-center py-12">
-              <p className="text-gray-600">レッスンが見つかりませんでした</p>
+              <p className="text-stone-600">レッスンが見つかりませんでした</p>
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {lessons.map((lesson) => (
-                <Link
-                  key={lesson.id}
-                  href={`/lessons/${lesson.id}`}
-                  className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow"
-                >
-                  {/* Placeholder Image */}
-                  <div className={`h-48 ${getCategoryColor(lesson.category)} flex items-center justify-center`}>
-                    <span className="text-6xl">
-                      {lesson.category === 'japanese' && '🍱'}
-                      {lesson.category === 'western' && '🍝'}
-                      {lesson.category === 'chinese' && '🥟'}
-                      {lesson.category === 'sweets' && '🍰'}
-                    </span>
-                  </div>
-                  <div className="p-6">
-                    <div className="flex gap-2 mb-3">
-                      <span className={`${getCategoryColor(lesson.category)} text-white text-xs px-2 py-1 rounded-full`}>
-                        {lesson.category_label}
-                      </span>
-                      <span className={`${getDifficultyColor(lesson.difficulty)} text-white text-xs px-2 py-1 rounded-full`}>
-                        {lesson.difficulty_label}
+              {lessons.map((lesson) => {
+                const catStyle = getCategoryStyle(lesson.category);
+                const diffStyle = getDifficultyStyle(lesson.difficulty);
+                return (
+                  <Link
+                    key={lesson.id}
+                    href={`/lessons/${lesson.id}`}
+                    className="bg-white rounded-2xl overflow-hidden hover:shadow-lg transition-all duration-300 border border-stone-100 group"
+                  >
+                    <div className={`h-40 bg-gradient-to-br ${catStyle.gradient} flex items-center justify-center`}>
+                      <span className="text-6xl group-hover:scale-110 transition-transform duration-300">
+                        {getCategoryEmoji(lesson.category)}
                       </span>
                     </div>
-                    <h3 className="text-lg font-bold text-gray-800 mb-2">
-                      {lesson.title}
-                    </h3>
-                    <p className="text-gray-600 text-sm line-clamp-2">
-                      {lesson.description}
-                    </p>
-                  </div>
-                </Link>
-              ))}
+                    <div className="p-6">
+                      <div className="flex gap-2 mb-3">
+                        <span className={`${catStyle.bg} ${catStyle.text} text-xs px-3 py-1 rounded-full font-medium`}>
+                          {lesson.category_label}
+                        </span>
+                        <span className={`${diffStyle.bg} ${diffStyle.text} text-xs px-3 py-1 rounded-full font-medium`}>
+                          {lesson.difficulty_label}
+                        </span>
+                      </div>
+                      <h3 className="text-lg font-bold text-stone-800 mb-2 group-hover:text-emerald-700 transition">
+                        {lesson.title}
+                      </h3>
+                      <p className="text-stone-600 text-sm line-clamp-2">
+                        {lesson.description}
+                      </p>
+                    </div>
+                  </Link>
+                );
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -34,30 +34,33 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            ログイン
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            または{' '}
-            <Link href="/register" className="font-medium text-orange-500 hover:text-orange-400">
-              新規会員登録
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full">
+        <div className="bg-white rounded-2xl border border-stone-100 p-8">
+          <div className="text-center mb-8">
+            <Link href="/" className="inline-block text-2xl font-bold text-stone-800 mb-2">
+              おうち<span className="text-emerald-700">シェフ</span>
             </Link>
-          </p>
-        </div>
+            <h1 className="text-xl font-bold text-stone-800">
+              ログイン
+            </h1>
+            <p className="mt-2 text-sm text-stone-600">
+              アカウントをお持ちでない方は{' '}
+              <Link href="/register" className="font-medium text-emerald-700 hover:text-emerald-800">
+                新規会員登録
+              </Link>
+            </p>
+          </div>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded">
-              {error}
-            </div>
-          )}
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-xl text-sm">
+                {error}
+              </div>
+            )}
 
-          <div className="rounded-md shadow-sm -space-y-px">
             <div>
-              <label htmlFor="email" className="sr-only">
+              <label htmlFor="email" className="block text-sm font-medium text-stone-700 mb-1">
                 メールアドレス
               </label>
               <input
@@ -66,14 +69,15 @@ export default function LoginPage() {
                 type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
-                placeholder="メールアドレス"
+                className="appearance-none block w-full px-4 py-3 border border-stone-200 rounded-xl placeholder-stone-400 text-stone-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                placeholder="example@email.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
               />
             </div>
+
             <div>
-              <label htmlFor="password" className="sr-only">
+              <label htmlFor="password" className="block text-sm font-medium text-stone-700 mb-1">
                 パスワード
               </label>
               <input
@@ -82,24 +86,22 @@ export default function LoginPage() {
                 type="password"
                 autoComplete="current-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                className="appearance-none block w-full px-4 py-3 border border-stone-200 rounded-xl placeholder-stone-400 text-stone-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 placeholder="パスワード"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
               />
             </div>
-          </div>
 
-          <div>
             <button
               type="submit"
               disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex justify-center py-3 px-4 border border-transparent rounded-xl text-white bg-emerald-700 hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? 'ログイン中...' : 'ログイン'}
             </button>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -98,19 +98,20 @@ export default function MyPage() {
 
   if (authLoading || (!user && !authLoading)) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-orange-500 border-t-transparent"></div>
+      <div className="min-h-screen bg-stone-50 flex items-center justify-center">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-stone-50">
       {/* Header */}
-      <section className="bg-orange-500 text-white py-12">
+      <section className="bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-3xl md:text-4xl font-bold">マイページ</h1>
-          <p className="mt-2 text-orange-100">{user?.name} さん</p>
+          <p className="text-emerald-700 font-medium mb-2">My Page</p>
+          <h1 className="text-3xl md:text-4xl font-bold text-stone-800">マイページ</h1>
+          <p className="mt-2 text-stone-600">{user?.name} さん</p>
         </div>
       </section>
 
@@ -119,33 +120,33 @@ export default function MyPage() {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Tickets Summary */}
             <div className="lg:col-span-1">
-              <div className="bg-white rounded-2xl shadow-lg p-6 sticky top-24">
-                <h2 className="text-xl font-bold text-gray-800 mb-4">チケット残数</h2>
+              <div className="bg-white rounded-2xl border border-stone-100 p-6 sticky top-24">
+                <h2 className="text-xl font-bold text-stone-800 mb-4">チケット残数</h2>
                 <div className="text-center py-6">
-                  <div className="text-5xl font-bold text-orange-500">
+                  <div className="text-5xl font-bold text-emerald-700">
                     {totalRemainingTickets}
                   </div>
-                  <div className="text-gray-600 mt-2">回分</div>
+                  <div className="text-stone-600 mt-2">回分</div>
                 </div>
 
                 {tickets.filter((t) => t.is_valid).length > 0 && (
-                  <div className="border-t pt-4 mt-4">
-                    <h3 className="text-sm font-medium text-gray-700 mb-2">チケット詳細</h3>
+                  <div className="border-t border-stone-100 pt-4 mt-4">
+                    <h3 className="text-sm font-medium text-stone-700 mb-2">チケット詳細</h3>
                     <div className="space-y-3">
                       {tickets
                         .filter((t) => t.is_valid)
                         .map((ticket) => (
                           <div
                             key={ticket.id}
-                            className="bg-gray-50 rounded-lg p-3"
+                            className="bg-stone-50 rounded-xl p-3"
                           >
                             <div className="flex justify-between">
-                              <span className="text-gray-600">{ticket.plan_label}</span>
-                              <span className="font-medium">
+                              <span className="text-stone-600">{ticket.plan_label}</span>
+                              <span className="font-medium text-stone-800">
                                 残り {ticket.remaining_count} 回
                               </span>
                             </div>
-                            <div className="text-xs text-gray-500 mt-1">
+                            <div className="text-xs text-stone-500 mt-1">
                               有効期限: {new Date(ticket.expires_at).toLocaleDateString('ja-JP')}
                             </div>
                           </div>
@@ -155,7 +156,7 @@ export default function MyPage() {
                 )}
 
                 {tickets.filter((t) => t.is_expired && t.remaining_count > 0).length > 0 && (
-                  <div className="border-t pt-4 mt-4">
+                  <div className="border-t border-stone-100 pt-4 mt-4">
                     <h3 className="text-sm font-medium text-red-600 mb-2">期限切れチケット</h3>
                     <div className="space-y-2">
                       {tickets
@@ -163,7 +164,7 @@ export default function MyPage() {
                         .map((ticket) => (
                           <div
                             key={ticket.id}
-                            className="bg-red-50 rounded-lg p-3 text-sm"
+                            className="bg-red-50 rounded-xl p-3 text-sm"
                           >
                             <div className="flex justify-between text-red-700">
                               <span>{ticket.plan_label}</span>
@@ -177,7 +178,7 @@ export default function MyPage() {
 
                 <Link
                   href="/tickets/purchase"
-                  className="mt-6 block w-full bg-orange-500 text-white text-center py-3 rounded-full font-medium hover:bg-orange-600 transition"
+                  className="mt-6 block w-full bg-emerald-700 text-white text-center py-3 rounded-xl font-medium hover:bg-emerald-800 transition"
                 >
                   チケットを購入
                 </Link>
@@ -188,28 +189,28 @@ export default function MyPage() {
             <div className="lg:col-span-2 space-y-8">
               {/* Viewed Lessons */}
               {viewedLessons.length > 0 && (
-                <div className="bg-white rounded-2xl shadow-lg p-6">
-                  <h2 className="text-xl font-bold text-gray-800 mb-4">最近見た講座</h2>
+                <div className="bg-white rounded-2xl border border-stone-100 p-6">
+                  <h2 className="text-xl font-bold text-stone-800 mb-4">最近見た講座</h2>
                   <div className="space-y-3">
                     {viewedLessons.map((lesson) => (
                       <Link
                         key={lesson.id}
                         href={`/lessons/${lesson.id}`}
-                        className="block border border-gray-200 rounded-xl p-4 hover:border-orange-300 hover:bg-orange-50 transition"
+                        className="block border border-stone-200 rounded-xl p-4 hover:border-emerald-300 hover:bg-emerald-50 transition"
                       >
                         <div className="flex items-center justify-between">
                           <div>
-                            <div className="font-medium text-gray-800">{lesson.title}</div>
+                            <div className="font-medium text-stone-800">{lesson.title}</div>
                             <div className="flex gap-2 mt-1">
-                              <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+                              <span className="text-xs bg-stone-100 text-stone-600 px-2 py-0.5 rounded-full">
                                 {lesson.category_label}
                               </span>
-                              <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+                              <span className="text-xs bg-stone-100 text-stone-600 px-2 py-0.5 rounded-full">
                                 {lesson.difficulty_label}
                               </span>
                             </div>
                           </div>
-                          <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <svg className="w-5 h-5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                           </svg>
                         </div>
@@ -220,20 +221,20 @@ export default function MyPage() {
               )}
 
               {/* Reservations */}
-              <div className="bg-white rounded-2xl shadow-lg p-6">
-                <h2 className="text-xl font-bold text-gray-800 mb-4">予約履歴</h2>
+              <div className="bg-white rounded-2xl border border-stone-100 p-6">
+                <h2 className="text-xl font-bold text-stone-800 mb-4">予約履歴</h2>
 
                 {isLoading ? (
                   <div className="text-center py-12">
-                    <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-orange-500 border-t-transparent"></div>
-                    <p className="mt-4 text-gray-600">読み込み中...</p>
+                    <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
+                    <p className="mt-4 text-stone-600">読み込み中...</p>
                   </div>
                 ) : reservations.length === 0 ? (
                   <div className="text-center py-12">
-                    <p className="text-gray-500">予約履歴がありません</p>
+                    <p className="text-stone-500">予約履歴がありません</p>
                     <Link
                       href="/lessons"
-                      className="mt-4 inline-block text-orange-500 hover:underline"
+                      className="mt-4 inline-block text-emerald-700 hover:underline"
                     >
                       レッスンを探す
                     </Link>
@@ -243,20 +244,20 @@ export default function MyPage() {
                     {reservations.map((reservation) => (
                       <div
                         key={reservation.id}
-                        className="border border-gray-200 rounded-xl p-4"
+                        className="border border-stone-200 rounded-xl p-4"
                       >
                         <div className="flex justify-between items-start">
                           <div>
                             {reservation.schedule?.lesson && (
                               <Link
                                 href={`/lessons/${reservation.schedule.lesson.id}`}
-                                className="text-lg font-bold text-gray-800 hover:text-orange-500"
+                                className="text-lg font-bold text-stone-800 hover:text-emerald-700"
                               >
                                 {reservation.schedule.lesson.title}
                               </Link>
                             )}
                             {reservation.schedule && (
-                              <div className="text-sm text-gray-600 mt-1">
+                              <div className="text-sm text-stone-600 mt-1">
                                 {formatDate(reservation.schedule.start_at)}{' '}
                                 {formatTime(reservation.schedule.start_at)} -{' '}
                                 {formatTime(reservation.schedule.end_at)}
@@ -266,12 +267,12 @@ export default function MyPage() {
                           <span
                             className={`px-3 py-1 rounded-full text-sm font-medium ${
                               reservation.status === 'reserved'
-                                ? 'bg-green-100 text-green-700'
+                                ? 'bg-emerald-100 text-emerald-800'
                                 : reservation.status === 'cancelled'
-                                ? 'bg-gray-100 text-gray-700'
+                                ? 'bg-stone-100 text-stone-700'
                                 : reservation.status === 'attended'
-                                ? 'bg-blue-100 text-blue-700'
-                                : 'bg-red-100 text-red-700'
+                                ? 'bg-sky-100 text-sky-800'
+                                : 'bg-red-100 text-red-800'
                             }`}
                           >
                             {reservation.status_label}
@@ -284,12 +285,12 @@ export default function MyPage() {
                               <button
                                 onClick={() => handleCancelClick(reservation)}
                                 disabled={cancellingId === reservation.id}
-                                className="text-sm text-red-500 hover:text-red-700 disabled:opacity-50"
+                                className="text-sm text-red-600 hover:text-red-800 disabled:opacity-50"
                               >
                                 予約をキャンセル
                               </button>
                             ) : (
-                              <span className="text-sm text-gray-400">
+                              <span className="text-sm text-stone-400">
                                 24時間前を過ぎたためキャンセル不可
                               </span>
                             )}
@@ -309,16 +310,16 @@ export default function MyPage() {
       {cancelModalReservation && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-2xl max-w-md w-full p-6">
-            <h3 className="text-xl font-bold text-gray-800 mb-4">
+            <h3 className="text-xl font-bold text-stone-800 mb-4">
               予約をキャンセルしますか？
             </h3>
 
             {cancelModalReservation.schedule?.lesson && (
-              <div className="bg-gray-50 rounded-xl p-4 mb-4">
-                <div className="font-medium text-gray-800">
+              <div className="bg-stone-50 rounded-xl p-4 mb-4">
+                <div className="font-medium text-stone-800">
                   {cancelModalReservation.schedule.lesson.title}
                 </div>
-                <div className="text-sm text-gray-600 mt-1">
+                <div className="text-sm text-stone-600 mt-1">
                   {formatDate(cancelModalReservation.schedule.start_at)}{' '}
                   {formatTime(cancelModalReservation.schedule.start_at)} -{' '}
                   {formatTime(cancelModalReservation.schedule.end_at)}
@@ -326,12 +327,12 @@ export default function MyPage() {
               </div>
             )}
 
-            <div className="bg-green-50 rounded-xl p-4 mb-6">
+            <div className="bg-emerald-50 rounded-xl p-4 mb-6 border border-emerald-100">
               <div className="flex items-center gap-2">
-                <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span className="text-green-700 font-medium">
+                <span className="text-emerald-800 font-medium">
                   チケット1回分が返却されます
                 </span>
               </div>
@@ -340,14 +341,14 @@ export default function MyPage() {
             <div className="flex gap-3">
               <button
                 onClick={() => setCancelModalReservation(null)}
-                className="flex-1 py-3 rounded-full border-2 border-gray-300 text-gray-700 font-medium hover:bg-gray-50 transition"
+                className="flex-1 py-3 rounded-xl border-2 border-stone-300 text-stone-700 font-medium hover:bg-stone-50 transition"
               >
                 戻る
               </button>
               <button
                 onClick={handleCancelConfirm}
                 disabled={cancellingId !== null}
-                className="flex-1 py-3 rounded-full bg-red-500 text-white font-medium hover:bg-red-600 transition disabled:opacity-50"
+                className="flex-1 py-3 rounded-xl bg-red-600 text-white font-medium hover:bg-red-700 transition disabled:opacity-50"
               >
                 {cancellingId !== null ? 'キャンセル中...' : 'キャンセルする'}
               </button>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,249 +3,512 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import api from '@/lib/api';
-import { Recipe } from '@/types/recipe';
+import { useAuth } from '@/contexts/AuthContext';
+import { Reservation, Ticket } from '@/types/reservation';
+
+type Lesson = {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  difficulty: string;
+  duration_minutes: number;
+  instructor?: {
+    name: string;
+  };
+};
 
 export default function Home() {
-  const [recipes, setRecipes] = useState<Recipe[]>([]);
-  const [isLoadingRecipes, setIsLoadingRecipes] = useState(true);
+  const { user, isLoading: authLoading } = useAuth();
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const fetchRecipes = async () => {
+    const fetchData = async () => {
       try {
-        const response = await api.get('/recipes/ranking');
-        setRecipes((response.data.recipes || []).slice(0, 4));
+        const lessonsRes = await api.get('/lessons');
+        setLessons((lessonsRes.data.data || []).slice(0, 4));
+
+        if (user) {
+          const [reservationsRes, ticketsRes] = await Promise.all([
+            api.get('/reservations'),
+            api.get('/tickets'),
+          ]);
+          setReservations(
+            (reservationsRes.data.data || [])
+              .filter((r: Reservation) => r.status === 'reserved')
+              .slice(0, 3)
+          );
+          setTickets(ticketsRes.data.data || []);
+        }
       } catch (error) {
-        console.error('レシピの取得に失敗しました', error);
+        console.error('データの取得に失敗しました', error);
       } finally {
-        setIsLoadingRecipes(false);
+        setIsLoading(false);
       }
     };
-    fetchRecipes();
-  }, []);
 
-  return (
-    <div>
-      {/* Hero Section - Orange */}
-      <section className="bg-orange-500 text-white py-24 md:py-32">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="max-w-3xl">
-            <h1 className="text-4xl md:text-6xl font-bold mb-6 leading-tight">
-              料理の楽しさを、
-              <br />
-              オンラインで。
-            </h1>
-            <p className="text-xl md:text-2xl mb-8 text-orange-100">
-              プロの料理人から学べる
-              <br className="md:hidden" />
-              オンライン料理教室
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4">
+    if (!authLoading) {
+      fetchData();
+    }
+  }, [user, authLoading]);
+
+  const categoryLabel: Record<string, string> = {
+    japanese: '和食',
+    western: '洋食',
+    chinese: '中華',
+    sweets: 'スイーツ',
+  };
+
+  const difficultyLabel: Record<string, string> = {
+    beginner: '初級',
+    intermediate: '中級',
+    advanced: '上級',
+  };
+
+  const categoryEmoji: Record<string, string> = {
+    japanese: '🍱',
+    western: '🍝',
+    chinese: '🥟',
+    sweets: '🍰',
+  };
+
+  const totalRemainingTickets = tickets
+    .filter((t) => t.is_valid)
+    .reduce((sum, t) => sum + t.remaining_count, 0);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      month: 'short',
+      day: 'numeric',
+      weekday: 'short',
+    });
+  };
+
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleTimeString('ja-JP', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  // ログイン後のトップページ
+  if (user) {
+    return (
+      <div className="bg-stone-50 min-h-screen">
+        {/* Logged-in Hero */}
+        <section className="bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-12">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+              <div>
+                <p className="text-emerald-700 font-medium mb-1">
+                  おかえりなさい
+                </p>
+                <h1 className="text-2xl md:text-3xl font-bold text-stone-800">
+                  {user.name} さん
+                </h1>
+              </div>
+              <div className="flex gap-3">
+                <Link
+                  href="/lessons"
+                  className="bg-emerald-700 text-white px-6 py-3 rounded-xl font-medium hover:bg-emerald-800 transition"
+                >
+                  レッスンを探す
+                </Link>
+                <Link
+                  href="/tickets/purchase"
+                  className="bg-white text-stone-700 px-6 py-3 rounded-xl font-medium border border-stone-200 hover:bg-stone-50 transition"
+                >
+                  チケット購入
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Dashboard Grid */}
+        <section className="py-8">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Ticket Summary Card */}
+              <div className="bg-white rounded-2xl border border-stone-100 p-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="font-bold text-stone-800">チケット残数</h2>
+                  <Link
+                    href="/tickets/purchase"
+                    className="text-sm text-emerald-700 hover:underline"
+                  >
+                    購入する
+                  </Link>
+                </div>
+                <div className="text-center py-4">
+                  <div className="text-4xl font-bold text-emerald-700">
+                    {totalRemainingTickets}
+                  </div>
+                  <div className="text-stone-500 text-sm mt-1">回分</div>
+                </div>
+                {totalRemainingTickets === 0 && (
+                  <p className="text-center text-sm text-stone-500 mt-2">
+                    チケットを購入してレッスンを予約しましょう
+                  </p>
+                )}
+              </div>
+
+              {/* Upcoming Reservations */}
+              <div className="lg:col-span-2 bg-white rounded-2xl border border-stone-100 p-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="font-bold text-stone-800">予約中のレッスン</h2>
+                  <Link
+                    href="/mypage"
+                    className="text-sm text-emerald-700 hover:underline"
+                  >
+                    すべて見る
+                  </Link>
+                </div>
+                {isLoading ? (
+                  <div className="text-center py-8">
+                    <div className="inline-block animate-spin rounded-full h-6 w-6 border-4 border-emerald-600 border-t-transparent"></div>
+                  </div>
+                ) : reservations.length > 0 ? (
+                  <div className="space-y-3">
+                    {reservations.map((reservation) => (
+                      <Link
+                        key={reservation.id}
+                        href={`/lessons/${reservation.schedule?.lesson?.id}`}
+                        className="block border border-stone-200 rounded-xl p-4 hover:border-emerald-300 hover:bg-emerald-50/50 transition"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="font-medium text-stone-800">
+                              {reservation.schedule?.lesson?.title}
+                            </div>
+                            {reservation.schedule && (
+                              <div className="text-sm text-stone-500 mt-1">
+                                {formatDate(reservation.schedule.start_at)}{' '}
+                                {formatTime(reservation.schedule.start_at)}〜
+                              </div>
+                            )}
+                          </div>
+                          <span className="bg-emerald-100 text-emerald-800 text-xs px-3 py-1 rounded-full font-medium">
+                            予約済み
+                          </span>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center py-8">
+                    <p className="text-stone-500 mb-4">予約中のレッスンはありません</p>
+                    <Link
+                      href="/lessons"
+                      className="inline-block text-emerald-700 font-medium hover:underline"
+                    >
+                      レッスンを探す →
+                    </Link>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Recommended Lessons */}
+        <section className="py-8">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex justify-between items-end mb-6">
+              <div>
+                <p className="text-emerald-700 font-medium mb-1">Recommended</p>
+                <h2 className="text-xl md:text-2xl font-bold text-stone-800">
+                  おすすめのレッスン
+                </h2>
+              </div>
               <Link
                 href="/lessons"
-                className="bg-white text-orange-500 px-8 py-4 rounded-full font-bold text-lg hover:bg-orange-50 transition text-center shadow-lg"
+                className="text-emerald-700 font-medium hover:underline hidden sm:block"
               >
-                レッスンを探す
+                すべて見る →
+              </Link>
+            </div>
+
+            {isLoading ? (
+              <div className="text-center py-12">
+                <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
+              </div>
+            ) : lessons.length > 0 ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                {lessons.map((lesson) => (
+                  <Link
+                    key={lesson.id}
+                    href={`/lessons/${lesson.id}`}
+                    className="bg-white rounded-2xl overflow-hidden hover:shadow-lg transition-all duration-300 group border border-stone-100"
+                  >
+                    <div className="h-28 bg-gradient-to-br from-amber-100 to-emerald-100 flex items-center justify-center">
+                      <span className="text-4xl">
+                        {categoryEmoji[lesson.category] || '🍳'}
+                      </span>
+                    </div>
+                    <div className="p-4">
+                      <div className="flex gap-2 mb-2">
+                        <span className="text-xs bg-amber-100 text-amber-800 px-2 py-1 rounded-full">
+                          {categoryLabel[lesson.category] || lesson.category}
+                        </span>
+                        <span className="text-xs bg-emerald-100 text-emerald-800 px-2 py-1 rounded-full">
+                          {difficultyLabel[lesson.difficulty] || lesson.difficulty}
+                        </span>
+                      </div>
+                      <h3 className="font-bold text-stone-800 mb-1 group-hover:text-emerald-700 transition text-sm">
+                        {lesson.title}
+                      </h3>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-center text-stone-500 py-8">
+                現在公開中のレッスンはありません
+              </p>
+            )}
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  // 未ログイン時のトップページ（従来のデザイン）
+  return (
+    <div className="bg-stone-50">
+      {/* Hero Section */}
+      <section className="relative bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-20 md:py-28 overflow-hidden">
+        <div className="absolute top-10 right-10 text-6xl opacity-10">👨‍🍳</div>
+        <div className="absolute bottom-10 left-10 text-5xl opacity-10">🥘</div>
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center max-w-3xl mx-auto">
+            <p className="text-emerald-700 font-medium mb-3">
+              オンライン料理教室
+            </p>
+            <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight text-stone-800">
+              プロと一緒に、
+              <br />
+              <span className="text-emerald-700">おうちで</span>料理しよう
+            </h1>
+            <p className="text-lg text-stone-600 mb-8 leading-relaxed">
+              自宅のキッチンから参加できるライブレッスン。
+              <br className="hidden md:block" />
+              わからないことは、その場で質問できます。
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link
+                href="/lessons"
+                className="bg-emerald-700 text-white px-8 py-4 rounded-xl font-bold text-lg hover:bg-emerald-800 transition shadow-md"
+              >
+                レッスンを見る
               </Link>
               <Link
                 href="/register"
-                className="border-2 border-white text-white px-8 py-4 rounded-full font-bold text-lg hover:bg-white hover:text-orange-500 transition text-center"
+                className="border-2 border-stone-300 text-stone-700 px-8 py-4 rounded-xl font-bold text-lg hover:bg-white transition"
               >
-                無料で始める
+                無料で会員登録
               </Link>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Categories Section - Yellow Green */}
-      <section className="bg-lime-400 py-20">
+      {/* Popular Lessons */}
+      <section className="bg-white py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-12 text-gray-800">
-            カテゴリから探す
-          </h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-            {[
-              { name: '和食', icon: '🍱', category: 'japanese', color: 'bg-red-500' },
-              { name: '洋食', icon: '🍝', category: 'western', color: 'bg-yellow-500' },
-              { name: '中華', icon: '🥟', category: 'chinese', color: 'bg-orange-500' },
-              { name: 'スイーツ', icon: '🍰', category: 'sweets', color: 'bg-pink-500' },
-            ].map((item) => (
-              <Link
-                key={item.category}
-                href={`/lessons?category=${item.category}`}
-                className={`${item.color} text-white rounded-2xl p-8 text-center hover:scale-105 transition-transform shadow-lg`}
-              >
-                <div className="text-5xl mb-4">{item.icon}</div>
-                <div className="font-bold text-xl">{item.name}</div>
-              </Link>
-            ))}
+          <div className="flex justify-between items-end mb-8">
+            <div>
+              <p className="text-emerald-700 font-medium mb-1">Lesson</p>
+              <h2 className="text-2xl md:text-3xl font-bold text-stone-800">
+                人気のレッスン
+              </h2>
+            </div>
+            <Link
+              href="/lessons"
+              className="text-emerald-700 font-medium hover:underline hidden sm:block"
+            >
+              すべて見る →
+            </Link>
           </div>
-        </div>
-      </section>
 
-      {/* Recipe Ranking Section */}
-      <section className="bg-gray-50 py-20">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-4 text-gray-800">
-            人気レシピランキング
-          </h2>
-          <p className="text-center text-gray-600 mb-12">
-            楽天レシピの人気ランキングをチェック
-          </p>
-          {isLoadingRecipes ? (
+          {isLoading ? (
             <div className="text-center py-12">
-              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-green-500 border-t-transparent"></div>
+              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
             </div>
-          ) : recipes.length > 0 ? (
+          ) : lessons.length > 0 ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {recipes.map((recipe) => (
-                <a
-                  key={recipe.recipeId}
-                  href={recipe.recipeUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="bg-gray-50 rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition group"
+              {lessons.map((lesson) => (
+                <Link
+                  key={lesson.id}
+                  href={`/lessons/${lesson.id}`}
+                  className="bg-stone-50 rounded-2xl overflow-hidden hover:shadow-lg transition-all duration-300 group border border-stone-100"
                 >
-                  <div className="relative h-48">
-                    <img
-                      src={recipe.foodImageUrl}
-                      alt={recipe.recipeTitle}
-                      className="w-full h-full object-cover group-hover:scale-105 transition"
-                    />
-                    <div className="absolute top-2 left-2 bg-green-600 text-white text-xs font-bold px-2 py-1 rounded">
-                      {recipe.rank}位
-                    </div>
+                  <div className="h-32 bg-gradient-to-br from-amber-100 to-emerald-100 flex items-center justify-center">
+                    <span className="text-5xl">
+                      {categoryEmoji[lesson.category] || '🍳'}
+                    </span>
                   </div>
                   <div className="p-4">
-                    <h3 className="font-bold text-gray-800 line-clamp-2 mb-2">
-                      {recipe.recipeTitle}
-                    </h3>
-                    <div className="flex items-center gap-2 text-sm text-gray-500">
-                      <span>{recipe.recipeIndication}</span>
-                      <span>•</span>
-                      <span>{recipe.recipeCost}</span>
+                    <div className="flex gap-2 mb-2">
+                      <span className="text-xs bg-amber-100 text-amber-800 px-2 py-1 rounded-full">
+                        {categoryLabel[lesson.category] || lesson.category}
+                      </span>
+                      <span className="text-xs bg-emerald-100 text-emerald-800 px-2 py-1 rounded-full">
+                        {difficultyLabel[lesson.difficulty] || lesson.difficulty}
+                      </span>
                     </div>
+                    <h3 className="font-bold text-stone-800 mb-1 group-hover:text-emerald-700 transition">
+                      {lesson.title}
+                    </h3>
+                    <p className="text-sm text-stone-500 line-clamp-2">
+                      {lesson.description}
+                    </p>
+                    {lesson.instructor && (
+                      <p className="text-xs text-stone-400 mt-2">
+                        講師: {lesson.instructor.name}
+                      </p>
+                    )}
                   </div>
-                </a>
+                </Link>
               ))}
             </div>
-          ) : null}
-          <div className="text-center mt-8">
+          ) : (
+            <p className="text-center text-stone-500 py-8">
+              現在公開中のレッスンはありません
+            </p>
+          )}
+
+          <div className="text-center mt-6 sm:hidden">
             <Link
-              href="/recipes"
-              className="inline-block bg-green-600 text-white px-8 py-3 rounded-full font-bold hover:bg-green-700 transition"
+              href="/lessons"
+              className="text-emerald-700 font-medium hover:underline"
             >
-              もっと見る
+              すべてのレッスンを見る →
             </Link>
           </div>
         </div>
       </section>
 
-      {/* Features Section - White */}
-      <section className="bg-white py-20">
+      {/* Features */}
+      <section className="bg-gradient-to-b from-stone-100 to-stone-50 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-4 text-gray-800">
-            Cooking Labの特徴
-          </h2>
-          <p className="text-center text-gray-600 mb-12">
-            初心者から上級者まで、あなたに合ったレッスンが見つかります
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div className="text-center p-6">
-              <div className="w-24 h-24 bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                <span className="text-5xl">👨‍🍳</span>
+          <div className="text-center mb-12">
+            <p className="text-emerald-700 font-medium mb-1">Feature</p>
+            <h2 className="text-2xl md:text-3xl font-bold text-stone-800">
+              おうちシェフの特徴
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="bg-white rounded-2xl p-6 border border-stone-100">
+              <div className="w-12 h-12 bg-emerald-100 rounded-xl flex items-center justify-center mb-4">
+                <span className="text-2xl">📱</span>
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">プロの講師陣</h3>
-              <p className="text-gray-600">
-                経験豊富なプロの料理人が
-                <br />
-                丁寧に指導します
+              <h3 className="font-bold text-lg mb-2 text-stone-800">
+                どこからでも参加
+              </h3>
+              <p className="text-stone-600 text-sm leading-relaxed">
+                スマホやPCがあれば、自宅のキッチンからライブで参加できます。
               </p>
             </div>
-            <div className="text-center p-6">
-              <div className="w-24 h-24 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                <span className="text-5xl">📱</span>
+
+            <div className="bg-white rounded-2xl p-6 border border-stone-100">
+              <div className="w-12 h-12 bg-amber-100 rounded-xl flex items-center justify-center mb-4">
+                <span className="text-2xl">💬</span>
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">いつでもどこでも</h3>
-              <p className="text-gray-600">
-                スマホ・PCから
-                <br />
-                好きな時間に参加できます
+              <h3 className="font-bold text-lg mb-2 text-stone-800">
+                その場で質問できる
+              </h3>
+              <p className="text-stone-600 text-sm leading-relaxed">
+                動画を見るだけじゃない。わからないことはリアルタイムで聞けます。
               </p>
             </div>
-            <div className="text-center p-6">
-              <div className="w-24 h-24 bg-yellow-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                <span className="text-5xl">🎫</span>
+
+            <div className="bg-white rounded-2xl p-6 border border-stone-100">
+              <div className="w-12 h-12 bg-pink-100 rounded-xl flex items-center justify-center mb-4">
+                <span className="text-2xl">👨‍🍳</span>
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">チケット制</h3>
-              <p className="text-gray-600">
-                お得なチケットで
-                <br />
-                好きなレッスンを自由に受講
+              <h3 className="font-bold text-lg mb-2 text-stone-800">
+                プロの講師が指導
+              </h3>
+              <p className="text-stone-600 text-sm leading-relaxed">
+                現役の料理人やパティシエから、本格的な技術を学べます。
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      {/* How it works Section - Tomato Red */}
-      <section className="bg-red-500 text-white py-20">
+      {/* How it works */}
+      <section className="bg-white py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
-            ご利用の流れ
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="text-center mb-12">
+            <p className="text-emerald-700 font-medium mb-1">How it works</p>
+            <h2 className="text-2xl md:text-3xl font-bold text-stone-800">
+              レッスンの流れ
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
             <div className="text-center">
-              <div className="w-20 h-20 bg-white text-red-500 rounded-full flex items-center justify-center mx-auto mb-4 text-3xl font-bold shadow-lg">
+              <div className="w-14 h-14 bg-emerald-700 text-white rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">
                 1
               </div>
-              <h3 className="text-xl font-bold mb-2">無料登録</h3>
-              <p className="text-red-100">
-                メールアドレスで
+              <h3 className="font-bold mb-2 text-stone-800">レッスンを予約</h3>
+              <p className="text-sm text-stone-600">
+                気になるレッスンを選んで
                 <br />
-                簡単登録
+                日程を予約します
               </p>
             </div>
+
             <div className="text-center">
-              <div className="w-20 h-20 bg-white text-red-500 rounded-full flex items-center justify-center mx-auto mb-4 text-3xl font-bold shadow-lg">
+              <div className="w-14 h-14 bg-emerald-700 text-white rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">
                 2
               </div>
-              <h3 className="text-xl font-bold mb-2">チケット購入</h3>
-              <p className="text-red-100">
-                1回券〜10回券から
+              <h3 className="font-bold mb-2 text-stone-800">材料を準備</h3>
+              <p className="text-sm text-stone-600">
+                レッスン前に届く
                 <br />
-                選べます
+                材料リストで買い出し
               </p>
             </div>
+
             <div className="text-center">
-              <div className="w-20 h-20 bg-white text-red-500 rounded-full flex items-center justify-center mx-auto mb-4 text-3xl font-bold shadow-lg">
+              <div className="w-14 h-14 bg-emerald-700 text-white rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">
                 3
               </div>
-              <h3 className="text-xl font-bold mb-2">レッスン予約</h3>
-              <p className="text-red-100">
-                好きなレッスンを
+              <h3 className="font-bold mb-2 text-stone-800">一緒に料理</h3>
+              <p className="text-sm text-stone-600">
+                当日はオンラインで
                 <br />
-                予約して参加
+                講師と一緒に作ります
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      {/* CTA Section - Green */}
-      <section className="bg-green-600 text-white py-20">
+      {/* CTA */}
+      <section className="bg-emerald-700 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold mb-6">
-            今すぐ始めよう
+          <h2 className="text-2xl md:text-3xl font-bold mb-4 text-white">
+            まずは会員登録から
           </h2>
-          <p className="text-xl text-green-100 mb-8">
-            無料登録で、すべてのレッスンをチェックできます
+          <p className="text-emerald-100 mb-8">
+            無料で登録して、レッスンをチェックしてみましょう
           </p>
           <Link
             href="/register"
-            className="inline-block bg-white text-green-600 px-10 py-4 rounded-full font-bold text-lg hover:bg-green-50 transition shadow-lg"
+            className="inline-block bg-white text-emerald-700 px-8 py-4 rounded-xl font-bold text-lg hover:bg-emerald-50 transition shadow-md"
           >
-            無料で登録する
+            無料で会員登録
           </Link>
         </div>
       </section>

--- a/frontend/src/app/recipes/page.tsx
+++ b/frontend/src/app/recipes/page.tsx
@@ -43,31 +43,32 @@ export default function RecipesPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-stone-50">
       {/* Header */}
-      <section className="bg-green-600 text-white py-12">
+      <section className="bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link href="/" className="inline-flex items-center text-white/80 hover:text-white mb-4">
+          <Link href="/" className="inline-flex items-center text-stone-600 hover:text-emerald-700 mb-4 transition">
             <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             トップに戻る
           </Link>
-          <h1 className="text-3xl md:text-4xl font-bold">人気レシピ</h1>
-          <p className="mt-2 text-green-100">楽天レシピの人気ランキングをチェック</p>
+          <p className="text-emerald-700 font-medium mb-2">Recipe Ranking</p>
+          <h1 className="text-3xl md:text-4xl font-bold text-stone-800">人気レシピ</h1>
+          <p className="mt-2 text-stone-600">楽天レシピの人気ランキングをチェック</p>
         </div>
       </section>
 
       {/* Category Filter */}
-      <section className="py-6 bg-white border-b">
+      <section className="py-6 bg-white border-b border-stone-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-wrap gap-2">
             <button
               onClick={() => setSelectedCategory('')}
               className={`px-4 py-2 rounded-full text-sm font-medium transition ${
                 selectedCategory === ''
-                  ? 'bg-green-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-emerald-700 text-white'
+                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200'
               }`}
             >
               すべて
@@ -78,8 +79,8 @@ export default function RecipesPage() {
                 onClick={() => setSelectedCategory(category.categoryId)}
                 className={`px-4 py-2 rounded-full text-sm font-medium transition ${
                   selectedCategory === category.categoryId
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    ? 'bg-emerald-700 text-white'
+                    : 'bg-stone-100 text-stone-700 hover:bg-stone-200'
                 }`}
               >
                 {category.categoryName}
@@ -94,12 +95,12 @@ export default function RecipesPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {isLoading ? (
             <div className="text-center py-12">
-              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-green-500 border-t-transparent"></div>
-              <p className="mt-4 text-gray-600">読み込み中...</p>
+              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-emerald-600 border-t-transparent"></div>
+              <p className="mt-4 text-stone-600">読み込み中...</p>
             </div>
           ) : recipes.length === 0 ? (
             <div className="text-center py-12">
-              <p className="text-gray-500">レシピが見つかりませんでした</p>
+              <p className="text-stone-500">レシピが見つかりませんでした</p>
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -109,7 +110,7 @@ export default function RecipesPage() {
                   href={recipe.recipeUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition group"
+                  className="bg-white rounded-2xl border border-stone-100 overflow-hidden hover:border-emerald-200 hover:shadow-lg transition group"
                 >
                   <div className="relative h-48">
                     <img
@@ -117,33 +118,33 @@ export default function RecipesPage() {
                       alt={recipe.recipeTitle}
                       className="w-full h-full object-cover group-hover:scale-105 transition"
                     />
-                    <div className="absolute top-2 left-2 bg-green-600 text-white text-xs font-bold px-2 py-1 rounded">
+                    <div className="absolute top-2 left-2 bg-amber-500 text-white text-xs font-bold px-2 py-1 rounded-lg">
                       {recipe.rank}位
                     </div>
                   </div>
                   <div className="p-4">
-                    <h3 className="font-bold text-gray-800 line-clamp-2 mb-2">
+                    <h3 className="font-bold text-stone-800 line-clamp-2 mb-2">
                       {recipe.recipeTitle}
                     </h3>
-                    <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+                    <div className="flex items-center gap-2 text-sm text-stone-500 mb-2">
                       <span>{recipe.recipeIndication}</span>
                       <span>•</span>
                       <span>{recipe.recipeCost}</span>
                     </div>
-                    <div className="text-xs text-gray-400">
+                    <div className="text-xs text-stone-400">
                       by {recipe.nickname}
                     </div>
                     <div className="mt-3 flex flex-wrap gap-1">
                       {recipe.recipeMaterial.slice(0, 3).map((material, index) => (
                         <span
                           key={index}
-                          className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded"
+                          className="bg-stone-100 text-stone-600 text-xs px-2 py-0.5 rounded-full"
                         >
                           {material}
                         </span>
                       ))}
                       {recipe.recipeMaterial.length > 3 && (
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-stone-400">
                           +{recipe.recipeMaterial.length - 3}
                         </span>
                       )}
@@ -155,13 +156,13 @@ export default function RecipesPage() {
           )}
 
           {/* Attribution */}
-          <div className="mt-8 text-center text-sm text-gray-500">
+          <div className="mt-8 text-center text-sm text-stone-500">
             レシピデータは
             <a
               href="https://recipe.rakuten.co.jp/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-green-600 hover:underline ml-1"
+              className="text-emerald-700 hover:underline ml-1"
             >
               楽天レシピ
             </a>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -42,30 +42,33 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            新規会員登録
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            または{' '}
-            <Link href="/login" className="font-medium text-orange-500 hover:text-orange-400">
-              ログイン
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full">
+        <div className="bg-white rounded-2xl border border-stone-100 p-8">
+          <div className="text-center mb-8">
+            <Link href="/" className="inline-block text-2xl font-bold text-stone-800 mb-2">
+              おうち<span className="text-emerald-700">シェフ</span>
             </Link>
-          </p>
-        </div>
+            <h1 className="text-xl font-bold text-stone-800">
+              新規会員登録
+            </h1>
+            <p className="mt-2 text-sm text-stone-600">
+              すでにアカウントをお持ちの方は{' '}
+              <Link href="/login" className="font-medium text-emerald-700 hover:text-emerald-800">
+                ログイン
+              </Link>
+            </p>
+          </div>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {generalError && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded">
-              {generalError}
-            </div>
-          )}
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            {generalError && (
+              <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-xl text-sm">
+                {generalError}
+              </div>
+            )}
 
-          <div className="space-y-4">
             <div>
-              <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="name" className="block text-sm font-medium text-stone-700 mb-1">
                 お名前
               </label>
               <input
@@ -73,7 +76,7 @@ export default function RegisterPage() {
                 name="name"
                 type="text"
                 required
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm"
+                className="appearance-none block w-full px-4 py-3 border border-stone-200 rounded-xl placeholder-stone-400 text-stone-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 placeholder="山田 太郎"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -84,7 +87,7 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="email" className="block text-sm font-medium text-stone-700 mb-1">
                 メールアドレス
               </label>
               <input
@@ -93,7 +96,7 @@ export default function RegisterPage() {
                 type="email"
                 autoComplete="email"
                 required
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm"
+                className="appearance-none block w-full px-4 py-3 border border-stone-200 rounded-xl placeholder-stone-400 text-stone-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 placeholder="example@email.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -104,7 +107,7 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="password" className="block text-sm font-medium text-stone-700 mb-1">
                 パスワード
               </label>
               <input
@@ -113,7 +116,7 @@ export default function RegisterPage() {
                 type="password"
                 autoComplete="new-password"
                 required
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm"
+                className="appearance-none block w-full px-4 py-3 border border-stone-200 rounded-xl placeholder-stone-400 text-stone-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 placeholder="8文字以上"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -124,7 +127,7 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label htmlFor="password_confirmation" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="password_confirmation" className="block text-sm font-medium text-stone-700 mb-1">
                 パスワード（確認）
               </label>
               <input
@@ -133,24 +136,22 @@ export default function RegisterPage() {
                 type="password"
                 autoComplete="new-password"
                 required
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm"
+                className="appearance-none block w-full px-4 py-3 border border-stone-200 rounded-xl placeholder-stone-400 text-stone-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 placeholder="パスワードを再入力"
                 value={passwordConfirmation}
                 onChange={(e) => setPasswordConfirmation(e.target.value)}
               />
             </div>
-          </div>
 
-          <div>
             <button
               type="submit"
               disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex justify-center py-3 px-4 border border-transparent rounded-xl text-white bg-emerald-700 hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? '登録中...' : '会員登録'}
             </button>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -2,41 +2,39 @@ import Link from 'next/link';
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-900 text-white">
+    <footer className="bg-stone-800 text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Logo & Description */}
           <div className="md:col-span-2">
-            <Link href="/" className="flex items-center space-x-2 mb-4">
-              <span className="text-2xl">🍳</span>
-              <span className="text-xl font-bold">
-                <span className="text-orange-400">Cooking</span>
-                <span className="text-green-400">Lab</span>
+            <Link href="/" className="flex items-center mb-4">
+              <span className="text-xl font-bold text-white">
+                おうち<span className="text-emerald-400">シェフ</span>
               </span>
             </Link>
-            <p className="text-gray-400 text-sm">
-              プロの料理人から学べるオンライン料理教室。
+            <p className="text-stone-400 text-sm leading-relaxed">
+              プロと一緒に、おうちで料理しよう。
               <br />
-              初心者から上級者まで、楽しく料理を学べます。
+              自宅のキッチンから参加できるオンライン料理教室です。
             </p>
           </div>
 
           {/* Links */}
           <div>
-            <h4 className="font-bold mb-4">サービス</h4>
-            <ul className="space-y-2 text-gray-400 text-sm">
+            <h4 className="font-bold mb-4 text-stone-200">サービス</h4>
+            <ul className="space-y-2 text-stone-400 text-sm">
               <li>
-                <Link href="/lessons" className="hover:text-white transition">
+                <Link href="/lessons" className="hover:text-emerald-400 transition">
                   レッスン一覧
                 </Link>
               </li>
               <li>
-                <Link href="/about" className="hover:text-white transition">
-                  Cooking Labとは
+                <Link href="/about" className="hover:text-emerald-400 transition">
+                  おうちシェフとは
                 </Link>
               </li>
               <li>
-                <Link href="/register" className="hover:text-white transition">
+                <Link href="/register" className="hover:text-emerald-400 transition">
                   無料登録
                 </Link>
               </li>
@@ -45,15 +43,15 @@ export default function Footer() {
 
           {/* Contact */}
           <div>
-            <h4 className="font-bold mb-4">お問い合わせ</h4>
-            <p className="text-gray-400 text-sm">
+            <h4 className="font-bold mb-4 text-stone-200">お問い合わせ</h4>
+            <p className="text-stone-400 text-sm">
               support@cookinglab.example.com
             </p>
           </div>
         </div>
 
-        <div className="border-t border-gray-800 mt-10 pt-8 text-center text-gray-500 text-sm">
-          © {new Date().getFullYear()} Cooking Lab. All rights reserved.
+        <div className="border-t border-stone-700 mt-10 pt-8 text-center text-stone-500 text-sm">
+          © {new Date().getFullYear()} おうちシェフ
         </div>
       </div>
     </footer>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -24,15 +24,13 @@ export default function Header() {
   };
 
   return (
-    <header className="bg-white sticky top-0 z-50">
+    <header className="bg-white/95 backdrop-blur-sm sticky top-0 z-50 border-b border-stone-100">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-20">
           {/* Logo */}
-          <Link href="/" className="flex items-center space-x-2">
-            <span className="text-3xl">🍳</span>
-            <span className="text-2xl font-bold">
-              <span className="text-orange-500">Cooking</span>
-              <span className="text-green-600">Lab</span>
+          <Link href="/" className="flex items-center">
+            <span className="text-2xl font-bold text-stone-800">
+              おうち<span className="text-emerald-700">シェフ</span>
             </span>
           </Link>
 
@@ -40,31 +38,31 @@ export default function Header() {
           <nav className="hidden md:flex items-center space-x-8">
             <Link
               href="/lessons"
-              className="text-gray-700 hover:text-orange-500 font-medium transition"
+              className="text-stone-600 hover:text-emerald-700 font-medium transition"
             >
               レッスン
             </Link>
             <Link
               href="/recipes"
-              className="text-gray-700 hover:text-green-600 font-medium transition"
+              className="text-stone-600 hover:text-emerald-700 font-medium transition"
             >
               レシピ
             </Link>
             <Link
               href="/about"
-              className="text-gray-700 hover:text-orange-500 font-medium transition"
+              className="text-stone-600 hover:text-emerald-700 font-medium transition"
             >
-              Cooking Labとは
+              おうちシェフとは
             </Link>
 
             {isLoading ? (
-              <span className="text-gray-400">...</span>
+              <span className="text-stone-400">...</span>
             ) : user ? (
               <>
                 {user.role === 'staff' && (
                   <Link
                     href="/admin"
-                    className="text-gray-700 hover:text-orange-500 font-medium transition"
+                    className="text-stone-600 hover:text-emerald-700 font-medium transition"
                   >
                     管理画面
                   </Link>
@@ -72,20 +70,20 @@ export default function Header() {
                 {user.role === 'instructor' && (
                   <Link
                     href="/instructor"
-                    className="text-gray-700 hover:text-orange-500 font-medium transition"
+                    className="text-stone-600 hover:text-emerald-700 font-medium transition"
                   >
                     講師管理
                   </Link>
                 )}
                 <Link
                   href="/mypage"
-                  className="text-gray-700 hover:text-orange-500 font-medium transition"
+                  className="text-stone-600 hover:text-emerald-700 font-medium transition"
                 >
                   マイページ
                 </Link>
                 <button
                   onClick={handleLogout}
-                  className="text-gray-700 hover:text-orange-500 font-medium transition"
+                  className="text-stone-600 hover:text-emerald-700 font-medium transition"
                 >
                   ログアウト
                 </button>
@@ -94,13 +92,13 @@ export default function Header() {
               <>
                 <Link
                   href="/login"
-                  className="text-gray-700 hover:text-orange-500 font-medium transition"
+                  className="text-stone-600 hover:text-emerald-700 font-medium transition"
                 >
                   ログイン
                 </Link>
                 <Link
                   href="/register"
-                  className="bg-orange-500 text-white px-6 py-2 rounded-full hover:bg-orange-600 font-medium transition"
+                  className="bg-emerald-700 text-white px-6 py-2 rounded-xl hover:bg-emerald-800 font-medium transition"
                 >
                   無料登録
                 </Link>
@@ -140,34 +138,34 @@ export default function Header() {
 
         {/* Mobile Navigation */}
         {isMenuOpen && (
-          <nav className="md:hidden pb-4 space-y-2">
+          <nav className="md:hidden pb-4 space-y-2 border-t border-stone-100 pt-4">
             <Link
               href="/lessons"
-              className="block py-2 text-gray-700 hover:text-orange-500"
+              className="block py-2 text-stone-600 hover:text-emerald-700"
             >
               レッスン
             </Link>
             <Link
               href="/recipes"
-              className="block py-2 text-gray-700 hover:text-green-600"
+              className="block py-2 text-stone-600 hover:text-emerald-700"
             >
               レシピ
             </Link>
             <Link
               href="/about"
-              className="block py-2 text-gray-700 hover:text-orange-500"
+              className="block py-2 text-stone-600 hover:text-emerald-700"
             >
-              Cooking Labとは
+              おうちシェフとは
             </Link>
 
             {isLoading ? (
-              <span className="block py-2 text-gray-400">...</span>
+              <span className="block py-2 text-stone-400">...</span>
             ) : user ? (
               <>
                 {user.role === 'staff' && (
                   <Link
                     href="/admin"
-                    className="block py-2 text-gray-700 hover:text-orange-500"
+                    className="block py-2 text-stone-600 hover:text-emerald-700"
                   >
                     管理画面
                   </Link>
@@ -175,20 +173,20 @@ export default function Header() {
                 {user.role === 'instructor' && (
                   <Link
                     href="/instructor"
-                    className="block py-2 text-gray-700 hover:text-orange-500"
+                    className="block py-2 text-stone-600 hover:text-emerald-700"
                   >
                     講師管理
                   </Link>
                 )}
                 <Link
                   href="/mypage"
-                  className="block py-2 text-gray-700 hover:text-orange-500"
+                  className="block py-2 text-stone-600 hover:text-emerald-700"
                 >
                   マイページ
                 </Link>
                 <button
                   onClick={handleLogout}
-                  className="block py-2 text-gray-700 hover:text-orange-500 text-left w-full"
+                  className="block py-2 text-stone-600 hover:text-emerald-700 text-left w-full"
                 >
                   ログアウト
                 </button>
@@ -197,13 +195,13 @@ export default function Header() {
               <>
                 <Link
                   href="/login"
-                  className="block py-2 text-gray-700 hover:text-orange-500"
+                  className="block py-2 text-stone-600 hover:text-emerald-700"
                 >
                   ログイン
                 </Link>
                 <Link
                   href="/register"
-                  className="block py-2 text-orange-500 font-medium"
+                  className="block py-2 text-emerald-700 font-medium"
                 >
                   無料登録
                 </Link>


### PR DESCRIPTION
## Ticket / Issue Number

#48

## What's changed

UI/UXデザインをナチュラル・オーガニックテーマに統一しました。

* サイト名を「CookingLab」から「おうちシェフ」に変更
* 全ページをナチュラルテーマ（emerald/stone/amber）で統一
* トップページをログイン状態に応じて表示切替
  * 未ログイン：LP（ヒーロー・特徴・ご利用の流れ・CTA）
  * ログイン済：ダッシュボード（チケット・予約・おすすめレッスン）
* 「おうちシェフとは」ページを新規作成

### 変更ファイル
| ファイル | 内容 |
|---------|------|
| Header.tsx | ロゴ・ナビゲーション更新 |
| Footer.tsx | フッター更新 |
| page.tsx | LP/ダッシュボード両対応 |
| lessons/page.tsx | レッスン一覧デザイン更新 |
| lessons/[id]/page.tsx | レッスン詳細デザイン更新 |
| mypage/page.tsx | マイページデザイン更新 |
| login/page.tsx | ログインページデザイン更新 |
| register/page.tsx | 登録ページデザイン更新 |
| recipes/page.tsx | レシピページデザイン更新 |
| about/page.tsx | 新規作成 |

## Todo List

- [ ] なし

## Check List

- [x] 全ページでデザインが統一されている
- [x] 未ログイン時：トップページにLPが表示される
- [x] ログイン時：トップページにダッシュボードが表示される
- [x] ヘッダーナビゲーションが正常に動作する
- [x] 「おうちシェフとは」ページが表示される
- [x] レシピページのデザインが統一されている

## Remark

デザインシステム:
- 背景: stone-50, グラデーション（from-amber-50 via-stone-50 to-emerald-50）
- テキスト: stone-800（見出し）, stone-600（本文）
- アクセント: emerald-700（ボタン・リンク）
- カード: rounded-2xl border border-stone-100
- ボタン: rounded-xl bg-emerald-700