### PR TITLE
[#56]feat: E2Eテスト（Playwright）

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { testUsers, login } from './fixtures';
+
+test.describe('認証フロー', () => {
+  test('ログインページが表示される', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.locator('h1')).toContainText('ログイン');
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+  });
+
+  test('正しい認証情報でログインできる', async ({ page }) => {
+    await login(page, testUsers.student);
+
+    // マイページリンクが表示されることを確認
+    await expect(page.locator('a[href="/mypage"]')).toBeVisible();
+  });
+
+  test('間違った認証情報でログインできない', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[type="email"]', 'wrong@example.com');
+    await page.fill('input[type="password"]', 'wrongpassword');
+    await page.click('button[type="submit"]');
+
+    // エラーメッセージが表示される
+    await expect(page.locator('text=メールアドレスまたはパスワードが正しくありません')).toBeVisible();
+  });
+
+  test('未ログイン時にマイページへアクセスするとログインページにリダイレクトされる', async ({ page }) => {
+    await page.goto('/mypage');
+
+    // ログインページにリダイレクト
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('ログイン後にマイページが表示される', async ({ page }) => {
+    await login(page, testUsers.student);
+    await page.goto('/mypage');
+
+    await expect(page.locator('h1')).toContainText('マイページ');
+    await expect(page.locator('text=チケット残数')).toBeVisible();
+  });
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,58 @@
+import { test as base, expect } from '@playwright/test';
+
+// テスト用のユーザー情報
+export const testUsers = {
+  student: {
+    email: 'test@example.com',
+    password: 'password',
+    name: 'テストユーザー',
+  },
+  instructor: {
+    email: 'instructor@example.com',
+    password: 'password',
+    name: '講師ユーザー',
+  },
+  staff: {
+    email: 'staff@example.com',
+    password: 'password',
+    name: '運営スタッフ',
+  },
+};
+
+// カスタムフィクスチャ
+export const test = base.extend<{
+  authenticatedPage: ReturnType<typeof base.page>;
+}>({
+  authenticatedPage: async ({ page }, use) => {
+    // ログイン処理
+    await page.goto('/login');
+    await page.fill('input[type="email"]', testUsers.student.email);
+    await page.fill('input[type="password"]', testUsers.student.password);
+    await page.click('button[type="submit"]');
+
+    // ログイン完了を待機
+    await page.waitForURL('/', { timeout: 10000 });
+
+    await use(page);
+  },
+});
+
+export { expect };
+
+// ヘルパー関数
+export async function login(
+  page: ReturnType<typeof base.page>,
+  user: { email: string; password: string }
+) {
+  await page.goto('/login');
+  await page.fill('input[type="email"]', user.email);
+  await page.fill('input[type="password"]', user.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('/', { timeout: 10000 });
+}
+
+export async function logout(page: ReturnType<typeof base.page>) {
+  // ヘッダーのログアウトボタンをクリック
+  await page.click('button:has-text("ログアウト")');
+  await page.waitForURL('/');
+}

--- a/frontend/e2e/reservation.spec.ts
+++ b/frontend/e2e/reservation.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { testUsers, login } from './fixtures';
+
+test.describe('予約フロー', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, testUsers.student);
+  });
+
+  test('レッスン一覧が表示される', async ({ page }) => {
+    await page.goto('/lessons');
+
+    await expect(page.locator('h1')).toContainText('レッスン一覧');
+  });
+
+  test('レッスン詳細ページが表示される', async ({ page }) => {
+    await page.goto('/lessons');
+
+    // 最初のレッスンカードをクリック
+    await page.locator('a[href^="/lessons/"]').first().click();
+
+    // レッスン詳細ページが表示される
+    await expect(page.locator('text=レッスン内容')).toBeVisible();
+    await expect(page.locator('text=開催スケジュール')).toBeVisible();
+  });
+
+  test('予約確認ページに遷移できる', async ({ page }) => {
+    await page.goto('/lessons');
+
+    // 最初のレッスンをクリック
+    await page.locator('a[href^="/lessons/"]').first().click();
+
+    // 予約ボタンをクリック（満席でない場合）
+    const reserveButton = page.locator('button:has-text("予約する")').first();
+
+    if (await reserveButton.isVisible()) {
+      await reserveButton.click();
+
+      // 予約確認ページに遷移
+      await expect(page).toHaveURL(/\/reservations\/confirm/);
+      await expect(page.locator('text=予約内容の確認')).toBeVisible();
+    }
+  });
+});
+
+test.describe('キャンセルフロー', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, testUsers.student);
+  });
+
+  test('マイページで予約一覧が表示される', async ({ page }) => {
+    await page.goto('/mypage');
+
+    await expect(page.locator('text=予約履歴')).toBeVisible();
+  });
+
+  test('予約をキャンセルできる', async ({ page }) => {
+    await page.goto('/mypage');
+
+    // キャンセルボタンが存在する場合
+    const cancelButton = page.locator('button:has-text("予約をキャンセル")').first();
+
+    if (await cancelButton.isVisible()) {
+      await cancelButton.click();
+
+      // 確認モーダルが表示される
+      await expect(page.locator('text=予約をキャンセルしますか')).toBeVisible();
+
+      // キャンセルを確定
+      await page.locator('button:has-text("キャンセルする")').click();
+
+      // 成功メッセージまたは状態の更新を確認
+      await expect(page.locator('text=キャンセル済み')).toBeVisible();
+    }
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "zustand": "^5.0.10"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -489,6 +490,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4411,6 +4428,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "axios": "^1.13.2",
@@ -16,6 +18,7 @@
     "zustand": "^5.0.10"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary

- Playwrightを導入してE2Eテストをセットアップ
- 認証フロー・予約フローのテストを作成

## Changes

- `playwright.config.ts` - Playwright設定
- `e2e/fixtures.ts` - テストヘルパー（ログイン処理など）
- `e2e/auth.spec.ts` - 認証テスト
- `e2e/reservation.spec.ts` - 予約・キャンセルテスト

## テストケース

### 認証テスト (5件)
- ログインページ表示
- 正常ログイン
- 認証エラー
- 未ログイン時リダイレクト
- マイページ表示

### 予約テスト (5件)
- レッスン一覧表示
- レッスン詳細表示
- 予約確認ページ遷移
- マイページ予約一覧
- キャンセル処理

## 実行方法

```bash
npm run test:e2e      # テスト実行
npm run test:e2e:ui   # UI付きで実行
```

## Test plan

- [ ] `npm run test:e2e` が実行できる
- [ ] 認証テストが動作する
- [ ] 予約テストが動作する

Closes #56